### PR TITLE
Coordinator dkg terminate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "frost-coordinator"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "backoff",
  "clap 4.1.4",

--- a/frost-coordinator/src/main.rs
+++ b/frost-coordinator/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use hashbrown::HashSet;
 use std::time::Duration;
-use tracing::info;
+use tracing::{debug, info};
 
 use frost_signer::config::Config;
 use frost_signer::logging;
@@ -142,7 +142,7 @@ where
         };
 
         let notify = |_err, dur| {
-            info!("No message. Next poll in {:?}", dur);
+            debug!("No message. Next poll in {:?}", dur);
         };
 
         let backoff_timer = backoff::ExponentialBackoffBuilder::new()

--- a/frost-coordinator/src/main.rs
+++ b/frost-coordinator/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use hashbrown::HashSet;
+use std::time::Duration;
 use tracing::info;
 
 use frost_signer::config::Config;
@@ -144,12 +145,10 @@ where
             info!("No message. Next poll in {:?}", dur);
         };
 
-        backoff::retry_notify(
-            backoff::ExponentialBackoff::default(),
-            get_next_message,
-            notify,
-        )
-        .map_err(|_| Error::Timeout)
+        let backoff_timer = backoff::ExponentialBackoffBuilder::new()
+            .with_max_interval(Duration::from_secs(3))
+            .build();
+        backoff::retry_notify(backoff_timer, get_next_message, notify).map_err(|_| Error::Timeout)
     }
 }
 

--- a/frost-coordinator/src/main.rs
+++ b/frost-coordinator/src/main.rs
@@ -124,11 +124,11 @@ where
                         dkg_end_msg.dkg_id, dkg_end_msg.signer_id, ids_to_await
                     );
                 }
-                (_, _) => {
-                    info!("wait for dkg catchall");
-                }
+                (_, _) => {}
             }
-            info!("wait for dkg bottom loop")
+            if ids_to_await.len() == 0 {
+                return Ok(());
+            }
         }
     }
 

--- a/frost-coordinator/src/main.rs
+++ b/frost-coordinator/src/main.rs
@@ -1,6 +1,7 @@
+use std::time::Duration;
+
 use clap::Parser;
 use hashbrown::HashSet;
-use std::time::Duration;
 use tracing::{debug, info};
 
 use frost_signer::config::Config;

--- a/frost-signer/src/signing_round.rs
+++ b/frost-signer/src/signing_round.rs
@@ -34,17 +34,18 @@ impl StateMachine for SigningRound {
     }
 
     fn can_move_to(&self, state: &States) -> Result<(), String> {
+        let previous_state = &self.state;
         let accepted = match state {
-            States::Init => false,
+            States::Idle => true,
             States::DkgDistribute => {
-                self.state == States::Init || self.state == States::DkgDistribute
+                self.state == States::Idle || self.state == States::DkgDistribute
             }
             States::DkgGather => self.state == States::DkgDistribute,
-            States::SignGather => self.state == States::DkgGather,
+            States::SignGather => self.state == States::Idle,
             States::Signed => self.state == States::SignGather,
         };
         if accepted {
-            info!("");
+            info!("state change from {:?} to {:?}", previous_state, state);
             Ok(())
         } else {
             Err(format!("bad state change: {:?} to {:?}", self.state, state))
@@ -146,7 +147,7 @@ impl SigningRound {
             threshold,
             total,
             signer,
-            state: States::Init,
+            state: States::Idle,
             commitments: HashMap::new(),
             shares: HashMap::new(),
         }
@@ -172,7 +173,7 @@ impl SigningRound {
                         signer_id: self.signer.signer_id as usize,
                     });
                     out.push(dkg_end);
-                    self.move_to(States::SignGather).unwrap();
+                    self.move_to(States::Idle).unwrap();
                 }
                 Ok(out)
             }

--- a/frost-signer/src/state_machine.rs
+++ b/frost-signer/src/state_machine.rs
@@ -1,6 +1,6 @@
 #[derive(Debug, PartialEq)]
 pub enum States {
-    Init,
+    Idle,
     DkgDistribute,
     DkgGather,
     SignGather,


### PR DESCRIPTION
this PR does 3 things

- checks for empty ids_to_wait_for to end the DKG round
- limits exponential backoff timer to 3sec max
- changes the state machine to go back to Idle once DKG round is over (used to require moving into signing phase but that was too tightly coupled)