### PR TITLE
Use `workspace.dependencies` if possible.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,22 +618,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "frost"
-version = "0.1.0"
-source = "git+https://github.com/trust-machines/frost?rev=8e188c271213e291e321b8aeda6273c054d25264#8e188c271213e291e321b8aeda6273c054d25264"
-dependencies = [
- "hashbrown 0.13.2",
- "hex",
- "num-traits",
- "p256k1",
- "polynomial",
- "rand_core 0.5.1",
- "serde",
- "sha3",
- "thiserror",
-]
-
-[[package]]
 name = "frost-coordinator"
 version = "0.0.1"
 dependencies = [
@@ -652,7 +636,6 @@ version = "0.0.1"
 dependencies = [
  "bincode",
  "clap 4.1.4",
- "frost",
  "hashbrown 0.13.2",
  "itertools",
  "p256k1",
@@ -665,18 +648,19 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq",
+ "wtfrost",
 ]
 
 [[package]]
 name = "frost-test"
 version = "0.1.0"
 dependencies = [
- "frost",
  "frost-coordinator",
  "frost-signer",
  "hashbrown 0.13.2",
  "rand_core 0.5.1",
  "relay-server",
+ "wtfrost",
 ]
 
 [[package]]
@@ -1868,12 +1852,12 @@ version = "0.0.1"
 dependencies = [
  "blockstack-core",
  "clap 4.1.4",
- "frost",
  "serde",
  "thiserror",
  "toml",
  "tracing",
  "tracing-subscriber",
+ "wtfrost",
 ]
 
 [[package]]
@@ -2552,6 +2536,23 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "wtfrost"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0acc8d879a1f7cdfa81a300476e316efcbefe005425ee1f22fdfbe5c2634bf"
+dependencies = [
+ "hashbrown 0.13.2",
+ "hex",
+ "num-traits",
+ "p256k1",
+ "polynomial",
+ "rand_core 0.5.1",
+ "serde",
+ "sha3",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,7 +638,6 @@ dependencies = [
  "clap 4.1.4",
  "hashbrown 0.13.2",
  "itertools",
- "p256k1",
  "rand 0.8.5",
  "rand_core 0.5.1",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 [[package]]
 name = "blockstack-core"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-blockchain/?branch=3493-sbtc-peg-out-wire-format#4dd923d69456cfab1ce577dcfd6d071d92ee62a4"
+source = "git+https://github.com/stacks-network/stacks-blockchain/?branch=3493-sbtc-peg-out-wire-format#041d10ac83e01b0aab43be1d720acb445f3ee861"
 dependencies = [
  "chrono",
  "clarity",
@@ -335,7 +335,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-blockchain/?branch=3493-sbtc-peg-out-wire-format#4dd923d69456cfab1ce577dcfd6d071d92ee62a4"
+source = "git+https://github.com/stacks-network/stacks-blockchain/?branch=3493-sbtc-peg-out-wire-format#041d10ac83e01b0aab43be1d720acb445f3ee861"
 dependencies = [
  "integer-sqrt",
  "lazy_static",
@@ -620,44 +620,12 @@ dependencies = [
 [[package]]
 name = "frost"
 version = "0.1.0"
-source = "git+https://github.com/trust-machines/frost?branch=sbtc#7e3f28dfb293d7c769c5158cf8d3481abfb19e26"
-dependencies = [
- "hashbrown 0.13.2",
- "hex",
- "num-traits",
- "p256k1 0.1.0",
- "polynomial",
- "rand_core 0.5.1",
- "serde",
- "sha3",
- "thiserror",
-]
-
-[[package]]
-name = "frost"
-version = "0.1.0"
 source = "git+https://github.com/trust-machines/frost?rev=8e188c271213e291e321b8aeda6273c054d25264#8e188c271213e291e321b8aeda6273c054d25264"
 dependencies = [
  "hashbrown 0.13.2",
  "hex",
  "num-traits",
- "p256k1 1.0.0",
- "polynomial",
- "rand_core 0.5.1",
- "serde",
- "sha3",
- "thiserror",
-]
-
-[[package]]
-name = "frost"
-version = "1.0.0"
-source = "git+https://github.com/trust-machines/frost?branch=main#1965f1258e3946063ef6d5c2e5c71042948541a8"
-dependencies = [
- "hashbrown 0.13.2",
- "hex",
- "num-traits",
- "p256k1 1.0.0",
+ "p256k1",
  "polynomial",
  "rand_core 0.5.1",
  "serde",
@@ -684,10 +652,10 @@ version = "0.0.1"
 dependencies = [
  "bincode",
  "clap 4.1.4",
- "frost 0.1.0 (git+https://github.com/trust-machines/frost?rev=8e188c271213e291e321b8aeda6273c054d25264)",
+ "frost",
  "hashbrown 0.13.2",
  "itertools",
- "p256k1 1.0.0",
+ "p256k1",
  "rand 0.8.5",
  "rand_core 0.5.1",
  "serde",
@@ -703,7 +671,7 @@ dependencies = [
 name = "frost-test"
 version = "0.1.0"
 dependencies = [
- "frost 1.0.0",
+ "frost",
  "frost-coordinator",
  "frost-signer",
  "hashbrown 0.13.2",
@@ -1192,26 +1160,6 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "p256k1"
-version = "0.1.0"
-source = "git+https://github.com/Trust-Machines/p256k1?branch=sbtc#5e27b7378614ac241cb48789d89cb411f1a4e355"
-dependencies = [
- "bindgen",
- "bitvec",
- "cc",
- "hex",
- "itertools",
- "num-traits",
- "proc-macro2",
- "quote",
- "rand_core 0.5.1",
- "rustfmt-wrapper",
- "serde",
- "sha3",
- "syn",
-]
 
 [[package]]
 name = "p256k1"
@@ -1891,7 +1839,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-blockchain/?branch=3493-sbtc-peg-out-wire-format#4dd923d69456cfab1ce577dcfd6d071d92ee62a4"
+source = "git+https://github.com/stacks-network/stacks-blockchain/?branch=3493-sbtc-peg-out-wire-format#041d10ac83e01b0aab43be1d720acb445f3ee861"
 dependencies = [
  "chrono",
  "curve25519-dalek",
@@ -1920,7 +1868,7 @@ version = "0.0.1"
 dependencies = [
  "blockstack-core",
  "clap 4.1.4",
- "frost 0.1.0 (git+https://github.com/trust-machines/frost?branch=sbtc)",
+ "frost",
  "serde",
  "thiserror",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ rand_core = "0.5"
 hashbrown = "0.13"
 bincode = "1.3.3"
 itertools = "^0.10.5"
-p256k1 = { version = "1.0" }
 sha3 = "0.10.6"
 ureq = { version = "2.6", features = [] }
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,22 @@ members = [
   "stacks-coordinator",
   "stacks-signer",
   ]
+
+[workspace.dependencies]
+blockstack-core = { git = "https://github.com/stacks-network/stacks-blockchain/", branch = "3493-sbtc-peg-out-wire-format" }
+clap = { version = "4.1.1", features = ["derive"] }
+frost = { git = "https://github.com/trust-machines/frost", rev = "8e188c271213e291e321b8aeda6273c054d25264" }
+serde = { version = "1.0", features = ["derive"] }
+tracing = "0.1.37"
+tracing-subscriber = "0.3.16"
+thiserror = "1.0"
+toml = "0.5.9"
+rand_core = "0.5"
+hashbrown = "0.13"
+bincode = "1.3.3"
+itertools = "^0.10.5"
+p256k1 = { version = "1.0" }
+sha3 = "0.10.6"
+ureq = { version = "2.6", features = [] }
+rand = "0.8.5"
+backoff = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 [workspace.dependencies]
 blockstack-core = { git = "https://github.com/stacks-network/stacks-blockchain/", branch = "3493-sbtc-peg-out-wire-format" }
 clap = { version = "4.1.1", features = ["derive"] }
-frost = { git = "https://github.com/trust-machines/frost", rev = "8e188c271213e291e321b8aeda6273c054d25264" }
+frost = { version = "1.0", package = "wtfrost" }
 serde = { version = "1.0", features = ["derive"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"

--- a/frost-coordinator/Cargo.toml
+++ b/frost-coordinator/Cargo.toml
@@ -9,12 +9,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-backoff = "0.4"
-clap = { version = "4.1.1", features = ["derive"] }
-hashbrown = { version = "0.13", features = ["serde"] }
-thiserror = "1.0"
-tracing = "0.1.37"
-tracing-subscriber = "0.3.16"
+backoff = { workspace = true }
+clap = { workspace = true }
+hashbrown = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 frost-signer = { version = "0.0.1", path = "../frost-signer" }
 
 [lib]

--- a/frost-signer/Cargo.toml
+++ b/frost-signer/Cargo.toml
@@ -17,7 +17,6 @@ frost = { workspace = true }
 hashbrown = { workspace = true }
 itertools = { workspace = true }
 rand_core = { workspace = true }
-p256k1 = { workspace = true }
 serde = { workspace = true }
 sha3 = { workspace = true }
 thiserror = { workspace = true }

--- a/frost-signer/Cargo.toml
+++ b/frost-signer/Cargo.toml
@@ -11,18 +11,18 @@ path = "src/lib.rs"    # The source file of the target.
 crate-type = ["lib"]   # The crate types to generate.
 
 [dependencies]
-bincode = "1.3.3"
-clap = { version = "4.1.1", features = ["derive"] }
-frost = { git = "https://github.com/trust-machines/frost", rev = "8e188c271213e291e321b8aeda6273c054d25264" }
-hashbrown = { version = "0.13", features = ["serde"] }
-itertools = "^0.10.5"
-rand_core = { version  = "0.5"}
-p256k1 = { version = "1.0" }
-serde = { version = "1.0", features = ["serde_derive"] }
-sha3 = "0.10.6"
-thiserror = "1.0"
-toml = "0.5.9"
-tracing = "0.1.37"
-tracing-subscriber = "0.3.16"
-ureq = { version = "2.6", features = [] }
-rand = "0.8.5"
+bincode = { workspace = true }
+clap = { workspace = true }
+frost = { workspace = true }
+hashbrown = { workspace = true }
+itertools = { workspace = true }
+rand_core = { workspace = true }
+p256k1 = { workspace = true }
+serde = { workspace = true }
+sha3 = { workspace = true }
+thiserror = { workspace = true }
+toml = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+ureq = { workspace = true }
+rand = { workspace = true }

--- a/frost-signer/src/signing_round.rs
+++ b/frost-signer/src/signing_round.rs
@@ -1,5 +1,8 @@
 pub use frost;
-use frost::{common::{PolyCommitment, PublicNonce}, Scalar};
+use frost::{
+    common::{PolyCommitment, PublicNonce},
+    Scalar,
+};
 use hashbrown::HashMap;
 use rand_core::OsRng;
 use serde::{Deserialize, Serialize};
@@ -310,9 +313,9 @@ impl SigningRound {
 
 #[cfg(test)]
 mod test {
-    use frost::Scalar;
     use frost::common::PolyCommitment;
     use frost::schnorr::ID;
+    use frost::Scalar;
     use hashbrown::HashMap;
     use rand_core::{CryptoRng, OsRng, RngCore};
 

--- a/frost-signer/src/signing_round.rs
+++ b/frost-signer/src/signing_round.rs
@@ -1,7 +1,6 @@
 pub use frost;
-use frost::common::{PolyCommitment, PublicNonce};
+use frost::{common::{PolyCommitment, PublicNonce}, Scalar};
 use hashbrown::HashMap;
-use p256k1::scalar::Scalar;
 use rand_core::OsRng;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -311,10 +310,10 @@ impl SigningRound {
 
 #[cfg(test)]
 mod test {
+    use frost::Scalar;
     use frost::common::PolyCommitment;
     use frost::schnorr::ID;
     use hashbrown::HashMap;
-    use p256k1::scalar::Scalar;
     use rand_core::{CryptoRng, OsRng, RngCore};
 
     use crate::signing_round::{DkgPublicShare, MessageTypes, SigningRound};

--- a/frost-test/Cargo.toml
+++ b/frost-test/Cargo.toml
@@ -10,6 +10,6 @@ license = "GPLv3"
 relay-server = { path = "../relay-server" }
 frost-coordinator = { path = "../frost-coordinator" }
 frost-signer = { path = "../frost-signer" }
-rand_core = "0.5"
-hashbrown = "0.13"
-frost = { git = "https://github.com/trust-machines/frost", branch = "main" }
+rand_core = { workspace = true }
+hashbrown = { workspace = true }
+frost = { workspace = true }

--- a/stacks-coordinator/Cargo.toml
+++ b/stacks-coordinator/Cargo.toml
@@ -9,11 +9,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-blockstack-core = { git = "https://github.com/stacks-network/stacks-blockchain/", branch = "3493-sbtc-peg-out-wire-format" }
-clap = { version = "4.1.1", features = ["derive"] }
-frost = { git = "https://github.com/trust-machines/frost", branch = "sbtc" }
-serde = { version = "1.0", features = ["derive"] }
-tracing = "0.1.37"
-tracing-subscriber = "0.3.16"
-thiserror = "1.0"
-toml = "0.5.9"
+blockstack-core = { workspace = true }
+clap = { workspace = true }
+frost = { workspace = true }
+serde = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+thiserror = { workspace = true }
+toml = { workspace = true }


### PR DESCRIPTION
To avoid famous diamond dependency problem, we can use [workspace.dependencies](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table)