### PR TITLE
Add clippy-check to CI pipeline

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,3 +52,19 @@ jobs:
     - uses: actions/checkout@v3
     - name: Run fmt check
       run: cargo fmt --check
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings -A clippy::op-ref -A clippy::needless-range-loop


### PR DESCRIPTION
I just ended up taking the CI from Frost. Not sure if those two lints are valid to be ignored, but I assumed we should be consistent between all our repos. 