### PR TITLE
add README

### DIFF
--- a/frost-coordinator/README.md
+++ b/frost-coordinator/README.md
@@ -1,0 +1,15 @@
+## Frost-Coordinator
+
+## Sample run
+
+3 signers, message: [1,2,3,4]
+
+in separate terminals run:
+```
+relay-server $ cargo run
+frost-signer $ cargo run -- --id 3
+frost-signer $ cargo run -- --id 2
+frost-signer $ cargo run -- --id 1
+frost-coordinator $ cargo run dkg-sign -- 1 2 3 4
+
+```


### PR DESCRIPTION
Creates a README with steps to run frost-coordinator.

This came up twice today. Notes are copied from #48 
