### PR TITLE
Merge BIP-340 work back onto peg-out-2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 [workspace.dependencies]
 blockstack-core = { git = "https://github.com/stacks-network/stacks-blockchain/", branch = "3493-sbtc-peg-out-wire-format" }
 clap = { version = "4.1.1", features = ["derive"] }
-wtfrost = "3.0"
+wtfrost = { git = "https://github.com/Trust-Machines/frost", branch = "main" }
 rusqlite = "0.24.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/frost-coordinator/src/coordinator.rs
+++ b/frost-coordinator/src/coordinator.rs
@@ -378,7 +378,7 @@ pub enum Error {
     NetworkError(#[from] HttpNetError),
     #[error("No aggregate public key")]
     NoAggregatePublicKey,
-    #[error("Aggregate failed to sign")]
+    #[error("Aggregator failed to sign: {0}")]
     Aggregator(AggregatorError),
     #[error("BIP-340 error")]
     Bip340(Bip340Error),

--- a/frost-coordinator/src/coordinator.rs
+++ b/frost-coordinator/src/coordinator.rs
@@ -195,14 +195,11 @@ where
             .collect();
 
         info!(
-            "SignatureAggregator::new total_keys: {} threshold: {}",
+            "SignatureAggregator::new total_keys: {} threshold: {} commitments: {}",
             self.total_keys,
             self.threshold,
+            polys.len()
         );
-
-        for (id, share) in &self.dkg_public_shares {
-            info!("dkg public share {} {}", id, share.public_share);
-        }
         
         let mut aggregator =
             match v1::SignatureAggregator::new(self.total_keys, self.threshold, polys) {
@@ -256,10 +253,6 @@ where
         }
 
         // call aggregator.sign()
-        let nonce_ids = id_nonces
-            .iter()
-            .map(|(i, _)| *i)
-            .collect::<Vec<u32>>();
         let nonces = id_nonces
             .iter()
             .map(|(_i, n)| n.clone())
@@ -274,13 +267,6 @@ where
             nonces.len(),
             shares.len()
         );
-        info!("{:?}", &nonce_ids);
-        for nonce in &nonces {
-            info!("{}", nonce);
-        }
-        for share in &shares {
-            info!("{}", share.id);
-        }
 
         let sig = match aggregator.sign(msg, &nonces, &shares) {
             Ok(sig) => sig,

--- a/frost-coordinator/src/coordinator.rs
+++ b/frost-coordinator/src/coordinator.rs
@@ -195,11 +195,15 @@ where
             .collect();
 
         info!(
-            "SignatureAggregator::new total_keys: {} threshold: {} commitments: {} ",
+            "SignatureAggregator::new total_keys: {} threshold: {}",
             self.total_keys,
             self.threshold,
-            polys.len()
         );
+
+        for (id, share) in &self.dkg_public_shares {
+            info!("dkg public share {} {}", id, share.public_share);
+        }
+        
         let mut aggregator =
             match v1::SignatureAggregator::new(self.total_keys, self.threshold, polys) {
                 Ok(aggregator) => aggregator,
@@ -252,6 +256,10 @@ where
         }
 
         // call aggregator.sign()
+        let nonce_ids = id_nonces
+            .iter()
+            .map(|(i, _)| *i)
+            .collect::<Vec<u32>>();
         let nonces = id_nonces
             .iter()
             .map(|(_i, n)| n.clone())
@@ -266,6 +274,13 @@ where
             nonces.len(),
             shares.len()
         );
+        info!("{:?}", &nonce_ids);
+        for nonce in &nonces {
+            info!("{}", nonce);
+        }
+        for share in &shares {
+            info!("{}", share.id);
+        }
 
         let sig = match aggregator.sign(msg, &nonces, &shares) {
             Ok(sig) => sig,

--- a/frost-signer/src/signing_round.rs
+++ b/frost-signer/src/signing_round.rs
@@ -188,12 +188,10 @@ impl SigningRound {
             Ok(mut out) => {
                 if self.can_dkg_end() {
                     info!(
-                        "can_dkg_end==true. shares {}",
+                        "can_dkg_end==true. shares {} commitments {}",
                         self.shares.len(),
+                        self.commitments.len()
                     );
-                    for (id, comm) in &self.commitments {
-                        info!("{} {}", id, comm);
-                    }
                     let dkg_end_msgs = self.dkg_ended()?;
                     out.push(dkg_end_msgs);
                     self.move_to(States::Idle)?;
@@ -224,11 +222,12 @@ impl SigningRound {
                 shares.keys()
             );
             if let Err(secret_error) = party.compute_secret(shares, &commitments) {
-                warn!(
+                panic!(
                     "DKG round #{}: party {} compute_secret failed in : {}",
                     self.dkg_id, party.id, secret_error
                 );
             }
+            info!("Party #{} group key {}", party.id, party.group_key);
         }
         let dkg_end = MessageTypes::DkgEnd(DkgEnd {
             dkg_id: self.dkg_id,
@@ -302,11 +301,6 @@ impl SigningRound {
                 .collect();
             let signer_nonces: Vec<PublicNonce> =
                 sign_request.nonces.iter().map(|(_, n)| n.clone()).collect();
-            info!("signer ids: {:?}", &signer_ids);
-            info!("signer nonces:");
-            for nonce in &signer_nonces {
-                info!("{}", nonce);
-            }
             let share = party.sign(&sign_request.message, &signer_ids, &signer_nonces);
 
             let response = MessageTypes::SignShareResponse(SignatureShareResponse {

--- a/frost-signer/src/signing_round.rs
+++ b/frost-signer/src/signing_round.rs
@@ -188,10 +188,12 @@ impl SigningRound {
             Ok(mut out) => {
                 if self.can_dkg_end() {
                     info!(
-                        "can_dkg_end==true. shares {} commitments {}",
+                        "can_dkg_end==true. shares {}",
                         self.shares.len(),
-                        self.commitments.len()
                     );
+                    for (id, comm) in &self.commitments {
+                        info!("{} {}", id, comm);
+                    }
                     let dkg_end_msgs = self.dkg_ended()?;
                     out.push(dkg_end_msgs);
                     self.move_to(States::Idle)?;
@@ -300,6 +302,11 @@ impl SigningRound {
                 .collect();
             let signer_nonces: Vec<PublicNonce> =
                 sign_request.nonces.iter().map(|(_, n)| n.clone()).collect();
+            info!("signer ids: {:?}", &signer_ids);
+            info!("signer nonces:");
+            for nonce in &signer_nonces {
+                info!("{}", nonce);
+            }
             let share = party.sign(&sign_request.message, &signer_ids, &signer_nonces);
 
             let response = MessageTypes::SignShareResponse(SignatureShareResponse {

--- a/stacks-coordinator/src/coordinator.rs
+++ b/stacks-coordinator/src/coordinator.rs
@@ -2,7 +2,7 @@ use bitcoin::psbt::serialize::Serialize;
 use frost_coordinator::create_coordinator;
 use frost_signer::net::HttpNetListen;
 use std::sync::mpsc;
-use wtfrost::{common::Signature, Point};
+use wtfrost::{bip340::SchnorrProof, common::Signature, Point};
 
 use crate::config::Config;
 use crate::peg_wallet::{BitcoinWallet, PegWallet};
@@ -93,7 +93,7 @@ impl StacksCoordinator {
         Ok(self.frost_coordinator.run_distributed_key_generation()?)
     }
 
-    pub fn sign_message(&mut self, message: &str) -> Result<Signature> {
+    pub fn sign_message(&mut self, message: &str) -> Result<(Signature, SchnorrProof)> {
         Ok(self.frost_coordinator.sign_message(message.as_bytes())?)
     }
 }


### PR DESCRIPTION
Repeat DKG and nonce rounds until the aggregate public key and random commitment sum both have even y coords.  

Also display wrapped aggregation errors when logging.

There is a frost fix which this branch is pulling in via GitHub main rather than crates.io.  When we are satisfied there are no more frost/p256k1 changes necessary I will do new major semver releases of both.