### PR TITLE
Stacks coordinator - parsing responses from stacks-node

### DIFF
--- a/stacks-coordinator/src/stacks_node/client.rs
+++ b/stacks-coordinator/src/stacks_node/client.rs
@@ -120,14 +120,15 @@ impl StacksNode for NodeClient {
             .send()?;
 
         if response.status() != StatusCode::OK {
-            let json_response = response
-                .json::<serde_json::Value>()
+            let error_str = response
+                .text()
                 .map_err(|_| StacksNodeError::BehindChainTip)?;
-            let error_str = json_response.as_str().unwrap_or("Unknown Reason");
+
             warn!(
                 "Failed to broadcast transaction to the stacks node: {:?}",
                 error_str
             );
+
             return Err(StacksNodeError::BroadcastFailure(error_str.to_string()));
         }
         Ok(())


### PR DESCRIPTION
This successfully gets the error description even though it's a bit crude. At this moment I'm not sure why parsing it as JSON fails. I've checked and response contains the JSON content type header.

@jferrant if you have time feel free to assign yourself too and see what is causing this.