### PR TITLE
Add logging to improve coordinator debugging

### DIFF
--- a/stacks-coordinator/src/coordinator.rs
+++ b/stacks-coordinator/src/coordinator.rs
@@ -110,8 +110,14 @@ pub trait Coordinator: Sized {
 
     fn process_queue(&mut self) -> Result<()> {
         match self.peg_queue().sbtc_op()? {
-            Some(SbtcOp::PegIn(op)) => self.peg_in(op),
-            Some(SbtcOp::PegOutRequest(op)) => self.peg_out(op),
+            Some(SbtcOp::PegIn(op)) => {
+                debug!("Processing peg in request: {:?}", op);
+                self.peg_in(op)
+            }
+            Some(SbtcOp::PegOutRequest(op)) => {
+                debug!("Processing peg out request: {:?}", op);
+                self.peg_out(op)
+            }
             None => Ok(()),
         }
     }
@@ -133,6 +139,7 @@ trait CoordinatorHelpers: Coordinator {
         // Broadcast the resulting sBTC transaction to the stacks node
         self.stacks_node().broadcast_transaction(&tx)?;
         info!("Broadcasted deposit sBTC transaction: {}", tx.txid());
+
         Ok(())
     }
 

--- a/stacks-coordinator/src/coordinator.rs
+++ b/stacks-coordinator/src/coordinator.rs
@@ -132,6 +132,7 @@ trait CoordinatorHelpers: Coordinator {
 
         // Broadcast the resulting sBTC transaction to the stacks node
         self.stacks_node().broadcast_transaction(&tx)?;
+        info!("Broadcasted deposit sBTC transaction: {}", tx.txid());
         Ok(())
     }
 
@@ -148,12 +149,20 @@ trait CoordinatorHelpers: Coordinator {
 
         // Broadcast the resulting sBTC transaction to the stacks node
         self.stacks_node().broadcast_transaction(&burn_tx)?;
+        info!(
+            "Broadcasted withdrawal sBTC transaction: {}",
+            burn_tx.txid()
+        );
 
         // Build and sign a fulfilled bitcoin transaction
         let fulfill_tx = self.fulfill_peg_out(&op)?;
 
         // Broadcast the resulting BTC transaction to the Bitcoin node
         self.bitcoin_node().broadcast_transaction(&fulfill_tx)?;
+        info!(
+            "Broadcasted fulfilled BTC transaction: {}",
+            fulfill_tx.txid()
+        );
         Ok(())
     }
 

--- a/stacks-coordinator/src/peg_queue/sqlite_peg_queue.rs
+++ b/stacks-coordinator/src/peg_queue/sqlite_peg_queue.rs
@@ -1,7 +1,6 @@
 use rusqlite::{Connection as RusqliteConnection, Error as RusqliteError, Row as SqliteRow};
 use std::path::Path;
 use std::str::FromStr;
-use std::time::Instant;
 
 use blockstack_lib::burnchains::Txid;
 use blockstack_lib::types::chainstate::BurnchainHeaderHash;
@@ -237,19 +236,12 @@ impl PegQueue for SqlitePegQueue {
             start_block_height, target_block_height
         );
 
-        let mut timestamp = Instant::now();
-
         for block_height in start_block_height..=target_block_height {
             self.poll_peg_in_ops(stacks_node, block_height)?;
             self.poll_peg_out_request_ops(stacks_node, block_height)?;
             self.insert_last_processed_block_height(block_height)?;
-
-            if timestamp.elapsed().as_secs_f64() > 5.0 {
-                info!("Processed block height {}", block_height);
-                timestamp = Instant::now();
-            }
+            info!("Processed block height {}", block_height);
         }
-
         Ok(())
     }
 

--- a/stacks-coordinator/src/peg_queue/sqlite_peg_queue.rs
+++ b/stacks-coordinator/src/peg_queue/sqlite_peg_queue.rs
@@ -227,8 +227,10 @@ impl PegQueue for SqlitePegQueue {
             .last_processed_block_height()
             .map(|count| count + 1)
             .unwrap_or(self.start_block_height);
+
         if start_block_height > target_block_height {
-            return Ok(()); // Nothing to do
+            info!("No new blocks to process");
+            return Ok(());
         }
 
         info!(


### PR DESCRIPTION
 Added broadcast transactions txid logging and always print the last processed block height since once we have caught up to a chain tip, the spamminess of this log greatly decreases.
 
Feel free to push more logs to this PR. Will keep it open for a bit.